### PR TITLE
Makes port optional and exposes req.protocol to redirect

### DIFF
--- a/lib/node-force-domain.js
+++ b/lib/node-force-domain.js
@@ -4,7 +4,7 @@ var redirect = require('./redirect');
 
 var forceDomain = function (options) {
   return function (req, res, next) {
-    var newRoute = redirect(req.headers.host, req.url, options);
+    var newRoute = redirect(req.protocol, req.headers.host, req.url, options);
 
     if (!newRoute) {
       return next();

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -4,7 +4,7 @@ var _ = require('underscore');
 
 var rewrite = require('./rewrite');
 
-var redirect = function (hostHeader, url, options) {
+var redirect = function (protocol, hostHeader, url, options) {
   options = _.defaults(options, {
     protocol: 'http',
     type: 'temporary'
@@ -16,7 +16,7 @@ var redirect = function (hostHeader, url, options) {
 
   if (
     (hostname === 'localhost') ||
-    (hostname === options.hostname && port == options.port)
+    (hostname === options.hostname && port == options.port && protocol === options.protocol)
   ) {
     return;
   }

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -7,22 +7,21 @@ var rewrite = require('./rewrite');
 var redirect = function (hostHeader, url, options) {
   options = _.defaults(options, {
     protocol: 'http',
-    port: 80,
     type: 'temporary'
   });
 
-  var hostHeaderParts = (hostHeader || '').split(':'),
+  var hostHeaderParts = (hostHeader || '').split(':'),
       hostname = hostHeaderParts[0] || '',
-      port = (hostHeaderParts[1] - 0) || 80;
+      port = (hostHeaderParts[1] - 0) || undefined;
 
   if (
     (hostname === 'localhost') ||
-    (hostname === options.hostname && port === options.port)
+    (hostname === options.hostname && port == options.port)
   ) {
     return;
   }
 
-  var route = options.protocol + '://' + hostname + ':' + port + url,
+  var route = options.protocol + '://' + hostname + (!!port ? ':' + port : '') + url,
       rewrittenRoute = rewrite(route, options);
 
   return {

--- a/test/node-force-domainTests.js
+++ b/test/node-force-domainTests.js
@@ -123,6 +123,105 @@ suite('node-force-domain', function () {
     });
   });
 
+  suite('hostname and protocol', function () {
+    var app = express();
+
+    app.use(forceDomain({
+      protocol: 'https',
+      hostname: 'www.example.com'
+    }));
+
+    app.get('/', function (req, res) {
+      res.send(200);
+    });
+
+    var appHttps = https.createServer({
+      key: fs.readFileSync(path.join(__dirname, 'keys', 'privateKey.pem')),
+      cert: fs.readFileSync(path.join(__dirname, 'keys', 'certificate.pem')),
+      ca: [ fs.readFileSync(path.join(__dirname, 'keys', 'caCertificate.pem')) ]
+    }, app);
+
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+    
+    test('does not redirect on localhost.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'localhost:3000')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(200));
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects on correct host and port, but other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('protocol', 'http')
+        .set('host', 'www.example.com:4000')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(307));
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on correct host, but other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'www.example.com')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(307));
+          assert.that(res.header.location, is.equalTo('https://www.example.com/'));
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on any other host, other protocol.', function (done) {
+      request(app)
+        .get('/')
+        .set('host', 'www.thenativeweb.io')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(307));
+          assert.that(res.header.location, is.equalTo('https://www.example.com/'));
+          res.resume();
+          done();
+        });
+    });
+
+    test('redirects temporarily on any other host, same protocol.', function (done) {
+      request(appHttps)
+        .get('/')
+        .set('host', 'www.thenativeweb.io')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(307));
+          assert.that(res.header.location, is.equalTo('https://www.example.com/'));
+          res.resume();
+          done();
+        });
+    });
+    
+    test('does not redirect on correct protocol and host.', function (done) {
+      request(appHttps)
+        .get('/')
+        .set('protocol', 'https')
+        .set('host', 'www.example.com')
+        .end(function (err, res) {
+          assert.that(err, is.null());
+          assert.that(res.statusCode, is.equalTo(200));
+          res.resume();
+          done();
+        });
+    });    
+  });
+
+
   suite('hostname, port and protocol', function () {
     var app = express();
 

--- a/test/node-force-domainTests.js
+++ b/test/node-force-domainTests.js
@@ -158,11 +158,11 @@ suite('node-force-domain', function () {
     test('redirects on correct host and port, but other protocol.', function (done) {
       request(app)
         .get('/')
-        .set('protocol', 'http')
         .set('host', 'www.example.com:4000')
         .end(function (err, res) {
           assert.that(err, is.null());
           assert.that(res.statusCode, is.equalTo(307));
+          assert.that(res.header.location, is.equalTo('https://www.example.com:4000/'));
           res.resume();
           done();
         });
@@ -210,7 +210,6 @@ suite('node-force-domain', function () {
     test('does not redirect on correct protocol and host.', function (done) {
       request(appHttps)
         .get('/')
-        .set('protocol', 'https')
         .set('host', 'www.example.com')
         .end(function (err, res) {
           assert.that(err, is.null());

--- a/test/node-force-domainTests.js
+++ b/test/node-force-domainTests.js
@@ -53,7 +53,7 @@ suite('node-force-domain', function () {
         .end(function (err, res) {
           assert.that(err, is.null());
           assert.that(res.statusCode, is.equalTo(307));
-          assert.that(res.header.location, is.equalTo('http://www.example.com:80/'));
+          assert.that(res.header.location, is.equalTo('http://www.example.com/'));
           res.resume();
           done();
         });
@@ -238,7 +238,7 @@ suite('node-force-domain', function () {
         .end(function (err, res) {
           assert.that(err, is.null());
           assert.that(res.statusCode, is.equalTo(301));
-          assert.that(res.header.location, is.equalTo('http://www.example.com:80/'));
+          assert.that(res.header.location, is.equalTo('http://www.example.com/'));
           res.resume();
           done();
         });

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -7,7 +7,7 @@ var redirect = require('../lib/redirect');
 suite('redirect', function () {
   suite('returns undefined', function () {
     test('for localhost.', function () {
-      assert.that(redirect('localhost', '/foo/bar', {
+      assert.that(redirect('http', 'localhost', '/foo/bar', {
         protocol: 'https',
         hostname: 'www.thenativeweb.io',
         port: 4000
@@ -15,7 +15,7 @@ suite('redirect', function () {
     });
 
     test('for localhost:3000.', function () {
-      assert.that(redirect('localhost:3000', '/foo/bar', {
+      assert.that(redirect('http', 'localhost:3000', '/foo/bar', {
         protocol: 'https',
         hostname: 'www.thenativeweb.io',
         port: 4000
@@ -23,7 +23,7 @@ suite('redirect', function () {
     });
 
     test('for the forced domain with the correct port.', function () {
-      assert.that(redirect('www.thenativeweb.io:4000', '/foo/bar', {
+      assert.that(redirect('http', 'www.thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000
       }), is.undefined());
@@ -32,7 +32,7 @@ suite('redirect', function () {
 
   suite('returns a temporary redirect', function () {
     test('for the forced domain with another port.', function () {
-      assert.that(redirect('www.thenativeweb.io:3000', '/foo/bar', {
+      assert.that(redirect('http', 'www.thenativeweb.io:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000
       }), is.equalTo({
@@ -42,7 +42,7 @@ suite('redirect', function () {
     });
 
     test('for another domain with the correct port.', function () {
-      assert.that(redirect('thenativeweb.io:4000', '/foo/bar', {
+      assert.that(redirect('http', 'thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000
       }), is.equalTo({
@@ -52,7 +52,7 @@ suite('redirect', function () {
     });
 
     test('for another domain with another port.', function () {
-      assert.that(redirect('thenativeweb.io:3000', '/foo/bar', {
+      assert.that(redirect('http', 'thenativeweb.io:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000
       }), is.equalTo({
@@ -64,7 +64,7 @@ suite('redirect', function () {
 
   suite('returns a permanent redirect', function () {
     test('for the forced domain with another port.', function () {
-      assert.that(redirect('www.thenativeweb.io:3000', '/foo/bar', {
+      assert.that(redirect('http', 'www.thenativeweb.io:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000,
         type: 'permanent'
@@ -75,7 +75,7 @@ suite('redirect', function () {
     });
 
     test('for another domain with the correct port.', function () {
-      assert.that(redirect('thenativeweb.io:4000', '/foo/bar', {
+      assert.that(redirect('http', 'thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000,
         type: 'permanent'
@@ -86,7 +86,7 @@ suite('redirect', function () {
     });
 
     test('for another domain with another port.', function () {
-      assert.that(redirect('thenativeweb.io:3000', '/foo/bar', {
+      assert.that(redirect('http', 'thenativeweb.io:3000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000,
         type: 'permanent'


### PR DESCRIPTION
In order to properly redirect http://example.com to https://example.com regardless of port